### PR TITLE
Attempt fix broken Helm init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apk add --no-cache ca-certificates jq curl bash nodejs && \
 #    chmod +x /usr/bin/helm3 && \
 #    rm -rf linux-amd64 && \
     # Init version 2 helm:
-    helm init --client-only --home=/etc/.helm
+    helm init --client-only --stable-repo-url https://charts.helm.sh/stable --home=/etc/.helm
 
 COPY . /usr/src/
 ENTRYPOINT ["node", "/usr/src/index.js"]


### PR DESCRIPTION
Attempt fix broken Helm init

See: https://developercommunity.visualstudio.com/content/problem/1293714/httpskubernetes-chartsstoragegoogleapiscom-is-not.html